### PR TITLE
Add base64 encoded response attribute to http data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0 (unreleased)
+
+ENHANCEMENTS:
+
+* data-source/http: `response_body_base64_std` has been added and contains a standard base64 encoding of the response body ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
+* data-source/http: Replaced issuing warning on the basis of possible non-text `Content-Type` with issuing warning if response body does not contain valid UTF-8. ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
+
 ## 3.2.1 (November 7, 2022)
 
 BUG FIXES
@@ -10,6 +17,7 @@ ENHANCEMENTS:
 
 * data-source/http: Added `ca_cert_pem` attribute which allows PEM encoded certificate(s) to be included in the set of root certificate authorities used when verifying server certificates ([#125](https://github.com/hashicorp/terraform-provider-http/pull/125)).
 * data-source/http: Added `insecure` attribute to allow disabling the verification of a server's certificate chain and host name. Defaults to `false` ([#125](https://github.com/hashicorp/terraform-provider-http/pull/125)).
+=======
 
 ## 3.1.0 (August 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ ENHANCEMENTS:
 
 * data-source/http: Added `ca_cert_pem` attribute which allows PEM encoded certificate(s) to be included in the set of root certificate authorities used when verifying server certificates ([#125](https://github.com/hashicorp/terraform-provider-http/pull/125)).
 * data-source/http: Added `insecure` attribute to allow disabling the verification of a server's certificate chain and host name. Defaults to `false` ([#125](https://github.com/hashicorp/terraform-provider-http/pull/125)).
-=======
 
 ## 3.1.0 (August 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 
-* data-source/http: `response_body_base64_std` has been added and contains a standard base64 encoding of the response body ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
+* data-source/http: `response_body_base64` has been added and contains a standard base64 encoding of the response body ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
 * data-source/http: Replaced issuing warning on the basis of possible non-text `Content-Type` with issuing warning if response body does not contain valid UTF-8. ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
 
 ## 3.2.1 (November 7, 2022)

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -154,5 +154,6 @@ resource "null_resource" "example" {
 - `body` (String, Deprecated) The response body returned as a string. **NOTE**: This is deprecated, use `response_body` instead.
 - `id` (String) The URL used for the request.
 - `response_body` (String) The response body returned as a string.
+- `response_body_base64_std` (String) The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
 - `response_headers` (Map of String) A map of response header field names and values. Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).
 - `status_code` (Number) The HTTP response status code.

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -154,6 +154,6 @@ resource "null_resource" "example" {
 - `body` (String, Deprecated) The response body returned as a string. **NOTE**: This is deprecated, use `response_body` instead.
 - `id` (String) The URL used for the request.
 - `response_body` (String) The response body returned as a string.
-- `response_body_base64_std` (String) The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
+- `response_body_base64` (String) The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
 - `response_headers` (Map of String) A map of response header field names and values. Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).
 - `status_code` (Number) The HTTP response status code.

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -246,10 +246,10 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		// TODO(ddelnano): Determine the appropriate fix for this
 		// This causes acceptance tests to fail on all terraform v0.14 releases and is
 		// fixed in v0.15.0-alpha20210107.
-		resp.Diagnostics.AddWarning(
-			"Response body is not recognized as UTF-8",
-			"Terraform may not properly handle the response_body if the contents are binary.",
-		)
+		// resp.Diagnostics.AddWarning(
+		// 	"Response body is not recognized as UTF-8",
+		// 	"Terraform may not properly handle the response_body if the contents are binary.",
+		// )
 	}
 
 	responseBody := string(bytes)

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -243,13 +243,10 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	if !utf8.Valid(bytes) {
-		// TODO(ddelnano): Determine the appropriate fix for this
-		// This causes acceptance tests to fail on all terraform v0.14 releases and is
-		// fixed in v0.15.0-alpha20210107.
-		// resp.Diagnostics.AddWarning(
-		// 	"Response body is not recognized as UTF-8",
-		// 	"Terraform may not properly handle the response_body if the contents are binary.",
-		// )
+		resp.Diagnostics.AddWarning(
+			"Response body is not recognized as UTF-8",
+			"Terraform may not properly handle the response_body if the contents are binary.",
+		)
 	}
 
 	responseBody := string(bytes)


### PR DESCRIPTION
This is the same change as https://github.com/hashicorp/terraform-provider-http/pull/214. Since the Terraform team is not ready to make that change to the provider now, I'm planning to implement the necessary functionality in this fork so that https://github.com/terra-farm/terraform-provider-xenorchestra/issues/193 can be completed